### PR TITLE
[ Common ] 모달 공통 컴포넌트 UI 반응형으로 변경

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 export interface ModalProps {
   isShowing: boolean;
@@ -76,7 +76,7 @@ const StModalSubContent = styled.p<{ isFinishing?: boolean }>`
   display: ${({ isFinishing }) => (isFinishing ? 'block' : 'none')};
   margin-top: 0.5rem;
   position: fixed;
-  top: 50%;
+  top: 51%;
   left: 50%;
   transform: translate(-50%, -50%);
 

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -38,6 +38,9 @@ const Modal = (props: ModalProps) => {
 export default Modal;
 
 const StModalWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   position: fixed;
   top: 0;
   left: 0;
@@ -46,36 +49,36 @@ const StModalWrapper = styled.div`
 
   width: 100%;
   height: 100%;
+  padding: 0rem 6rem;
 
   background: rgba(0, 0, 0, 0.7);
 `;
 
 const StModal = styled.section`
   display: flex;
+  justify-content: space-between;
   align-items: center;
   flex-direction: column;
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  margin: auto;
 
-  width: 31rem;
-  height: 19.6rem;
+  width: 100%;
+  padding: 2.1rem 2.3rem;
 
   background-color: ${({ theme }) => theme.colors.Pic_Color_White};
   border-radius: 1rem;
 `;
 
 const StModalContent = styled.p`
-  margin-top: 7.4rem;
+  padding-top: 5.3rem;
   ${({ theme }) => theme.fonts.Pic_Body1_Pretendard_Medium_16};
 `;
 
 const StModalSubContent = styled.p<{ isFinishing?: boolean }>`
   display: ${({ isFinishing }) => (isFinishing ? 'block' : 'none')};
   margin-top: 0.5rem;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 
   color: ${({ theme }) => theme.colors.Pic_Color_Gray_4};
   font-family: 'Pretendard';
@@ -91,14 +94,12 @@ const StModalSubContent = styled.p<{ isFinishing?: boolean }>`
 
 const StButtonWrapper = styled.div`
   display: flex;
-  position: absolute;
-  bottom: 0;
   gap: 1.2rem;
-
-  padding: 2.1rem 2.3rem;
+  padding-top: 4rem;
+  width: 100%;
 
   > button {
-    width: 12.6rem;
+    width: 100%;
     height: 4.1rem;
 
     background: inherit;

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -7,10 +7,11 @@ export interface ModalProps {
   handleHide: React.MouseEventHandler;
   handleConfirm: React.MouseEventHandler;
   isFinishing?: boolean; // 투표 마감하기 버튼
+  isDeleteUser?: boolean; // 탈퇴하기 버튼
 }
 
 const Modal = (props: ModalProps) => {
-  const { isShowing, message, handleHide, handleConfirm, isFinishing } = props;
+  const { isShowing, message, handleHide, handleConfirm, isFinishing, isDeleteUser } = props;
   return (
     <>
       {isShowing && (
@@ -19,6 +20,9 @@ const Modal = (props: ModalProps) => {
             <StModalContent>{message}</StModalContent>
             <StModalSubContent isFinishing={isFinishing}>
               *마감된 투표는 <span>라이브러리</span>에서 확인 가능해요!
+            </StModalSubContent>
+            <StModalSubContent isDeleteUser={isDeleteUser}>
+              *탈퇴시 <span>계정 및 모든 데이터</span>들이 영구 삭제됩니다!
             </StModalSubContent>
             <StButtonWrapper>
               <button type="button" onClick={handleHide}>
@@ -72,8 +76,9 @@ const StModalContent = styled.p`
   ${({ theme }) => theme.fonts.Pic_Body1_Pretendard_Medium_16};
 `;
 
-const StModalSubContent = styled.p<{ isFinishing?: boolean }>`
+const StModalSubContent = styled.p<{ isFinishing?: boolean; isDeleteUser?: boolean }>`
   display: ${({ isFinishing }) => (isFinishing ? 'block' : 'none')};
+  display: ${({ isDeleteUser }) => (isDeleteUser ? 'block' : 'none')};
   margin-top: 0.5rem;
   position: fixed;
   top: 51%;


### PR DESCRIPTION
## 🔥 Related Issues
resolved #27 

## 💜 작업 내용
- [x] rem으로 지정해두었던 모달 크기를 %로 변경하여 반응형으로 구현하였습니다. 

## ✅ PR Point
- 재욱 시루가 알려준대로 width: 100%로 두고 padding으로 너비를 조정해주었습니다!!
- 마감된 투표인 경우에 나오는 하단 안내문구를 화면에 고정시켜 놓았는데 요렇게 해도 괜찮을까요?!
``` javascript
const StModalSubContent = styled.p<{ isFinishing?: boolean }>`
  display: ${({ isFinishing }) => (isFinishing ? 'block' : 'none')};
  margin-top: 0.5rem;
  position: fixed;
  top: 51%;
  left: 50%;
  transform: translate(-50%, -50%);

  color: ${({ theme }) => theme.colors.Pic_Color_Gray_4};
  font-family: 'Pretendard';
  font-style: normal;
  font-weight: 500;
  font-size: 0.9rem;
  line-height: 1.1rem;

  > span {
    color: ${({ theme }) => theme.colors.Pic_Color_Coral};
  }
`;
```

## 👀 스크린샷 / GIF / 링크

https://user-images.githubusercontent.com/73213437/211193265-3c0ec30c-5a90-4b1a-9f78-b6f11b0c72b1.mov

