### PR TITLE
[Home] 현재 진행중인 투표 스켈레톤 UI

### DIFF
--- a/src/components/Landing/maker/LandingVoteCard.tsx
+++ b/src/components/Landing/maker/LandingVoteCard.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+import { loading } from '../../common/style/animation';
+
+const LandingVoteCard = () => <LandingVoteCardWrapper />;
+
+export default LandingVoteCard;
+
+const LandingVoteCardWrapper = styled.section`
+  width: 25.7rem;
+  height: 15.4rem;
+
+  border-radius: 1.2rem;
+  background-color: ${({ theme }) => theme.colors.Pic_Color_Gray_4};
+
+  animation: ${loading} 2s infinite linear;
+`;

--- a/src/components/Landing/maker/LandingVoteList.tsx
+++ b/src/components/Landing/maker/LandingVoteList.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+import LandingVoteCard from './LandingVoteCard';
+
+const LandingVoteList = () => (
+  <StLandingVoteListWrapper>
+    <StLandingLi>
+      <LandingVoteCard />
+    </StLandingLi>
+    <StLandingLi>
+      <LandingVoteCard />
+    </StLandingLi>
+  </StLandingVoteListWrapper>
+);
+
+export default LandingVoteList;
+
+const StLandingVoteListWrapper = styled.main`
+  display: flex;
+
+  width: 100%;
+  padding-left: 2rem;
+
+  overflow-x: hidden;
+`;
+
+const StLandingLi = styled.li`
+  & + & {
+    margin-left: 1.6rem;
+  }
+  list-style: none;
+`;

--- a/src/components/Landing/maker/index.ts
+++ b/src/components/Landing/maker/index.ts
@@ -1,0 +1,2 @@
+export { default as LandingVoteCard } from './LandingVoteCard';
+export { default as LandingVoteList } from './LandingVoteList';

--- a/src/components/common/style/animation.ts
+++ b/src/components/common/style/animation.ts
@@ -1,0 +1,13 @@
+import { keyframes } from 'styled-components';
+
+export const loading = keyframes`
+  0% {
+        background-color: rgba(165, 165, 165, 0.1);
+    }
+    50% {
+        background-color: rgba(165, 165, 165, 0.3);
+    }
+    100% {
+        background-color: rgba(165, 165, 165, 0.1);
+    }
+`;


### PR DESCRIPTION
## 🔥 Related Issues
resolved #48 

## 💜 작업 내용
- [x] ~ 현재 진행중인 투표 랜딩 컴포넌트

## ✅ PR Point
- animation 코드는 서히 쇽샥 했습니당
- 무한스크롤이 있는 뷰이다 보니 무한스크롤이 필요한 현재 진행중인 투표 컴포넌트 부분한 로딩 처리를 해주었습니다.
- 현재 진행중인 투표 각각의 컴포넌트 넓이가 25.7rem으로 고정되어 있어 아무리 작은 핸드폰이여도 하나 이상 보일것 같아 두개의 아이템만 넣어줬습니다.
```javascript
const LandingVoteList = () => (
  <StLandingVoteListWrapper>
    <StLandingLi>
      <LandingVoteCard />
    </StLandingLi>
    <StLandingLi>
      <LandingVoteCard />
    </StLandingLi>
  </StLandingVoteListWrapper>
);
export default LandingVoteList;
```
- 2번째 아이템의 짤리는 부분을 표현하기 위해서 `overflow-x : hidden` 속성을 주었습니다.
```javascript
const StLandingVoteListWrapper = styled.main`
  display: flex;

  width: 100%;
  padding-left: 2rem;

  overflow-x: hidden;
`;
```


## 👀 스크린샷 / GIF / 링크

https://user-images.githubusercontent.com/69576360/211338215-a58085ae-ef4d-485f-abd1-d05ee0378c80.mp4


