### PR TITLE
[ 🔮 Sticker ] 스티커 삭제 기능 

### DIFF
--- a/src/asset/icon/ic_cancel.svg
+++ b/src/asset/icon/ic_cancel.svg
@@ -1,0 +1,5 @@
+<svg width="21" height="21" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10.5" cy="10.5" r="10" fill="#D9D9D9"/>
+<path d="M6.75 6.64185L14.25 14.1418" stroke="white" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M14.25 6.64185L6.75 14.1418" stroke="white" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/src/asset/icon/index.ts
+++ b/src/asset/icon/index.ts
@@ -15,6 +15,7 @@ export { ReactComponent as IcHomeLogo } from './homeLogo.svg';
 export { ReactComponent as IcAngle } from './ic_angle.svg';
 export { ReactComponent as IcAngleSticker } from './ic_angle.svg';
 export { ReactComponent as IcBackGroundSticker } from './ic_back_ground.svg';
+export { ReactComponent as IcCancel } from './ic_cancel.svg';
 export { ReactComponent as IcCheckedRound } from './ic_checked_round.svg';
 export { ReactComponent as IcClose } from './ic_close.svg';
 export { ReactComponent as IcCropImg } from './ic_cropImg.svg';

--- a/src/components/Voting/player/StickerVoting.tsx
+++ b/src/components/Voting/player/StickerVoting.tsx
@@ -52,7 +52,7 @@ const StickerVoting = (props: StickerVotingProps) => {
     }
   };
 
-  const handleCancelSticker = (e: React.MouseEvent<SVGSVGElement>) => {
+  const handleDeleteSticker = (e: React.MouseEvent<SVGSVGElement>) => {
     const stickerTarget = e.currentTarget as SVGSVGElement;
     const clickStickerIdx = Number(stickerTarget.dataset.sticker);
 
@@ -98,7 +98,7 @@ const StickerVoting = (props: StickerVotingProps) => {
             stickerList.map((sticker, idx) => (
               <StEmojiIcon key={`sticker.x${idx}`} location={setStickerLocationData(sticker, imgViewInfo, imgInfo)}>
                 {STICKER_LIST[emoji].icon((54 * imgViewInfo.width) / 390)}
-                <IcCancel onClick={handleCancelSticker} data-sticker={`${idx}`} />
+                <IcCancel onClick={handleDeleteSticker} data-sticker={`${idx}`} />
               </StEmojiIcon>
             ))}
         </article>

--- a/src/components/Voting/player/StickerVoting.tsx
+++ b/src/components/Voting/player/StickerVoting.tsx
@@ -2,23 +2,28 @@ import { useRef, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
+import { IcCancel } from '../../../asset/icon';
 import { STICKER_LIST } from '../../../constant/StickerIconList';
+import useModal from '../../../lib/hooks/useModal';
 import { playerStickerInfoState } from '../../../recoil/player/atom';
 import { pictureSelector } from '../../../recoil/player/selector';
 import { NaturalImgInfo, StickerLocation } from '../../../types/vote';
 import { setStickerLocationData } from '../../../utils/setStickerLocationData';
+import Modal from '../../common/Modal';
 
 interface StickerVotingProps {
   isStickerGuide: boolean;
 }
 const StickerVoting = (props: StickerVotingProps) => {
   const { isStickerGuide } = props;
+
   const [stickerVotingInfo, setStickerVotingInfo] = useRecoilState(playerStickerInfoState);
   const { location: stickerList, emoji } = stickerVotingInfo;
   const pictureInfo = useRecoilValue(pictureSelector(stickerVotingInfo.pictureId));
   const stickerImgRef = useRef<HTMLImageElement>(null);
   const [imgInfo, setImgInfo] = useState<NaturalImgInfo>();
   const [imgViewInfo, setImgViewInfo] = useState<NaturalImgInfo>();
+  const { isShowing, toggle } = useModal();
 
   const handleImgSize = (e: React.SyntheticEvent) => {
     const { naturalWidth, naturalHeight, width, height } = e.target as HTMLImageElement;
@@ -34,6 +39,7 @@ const StickerVoting = (props: StickerVotingProps) => {
           x: Math.round((((offsetX - 27) * imgInfo.width) / imgViewInfo.width) * 100) / 100,
           y: Math.round((((offsetY - 27) * imgInfo.height) / imgViewInfo.height) * 100) / 100,
           degRate: Math.round((Math.random() * 250 - 115) * 100) / 100,
+          isDelete: false,
         };
 
         setStickerVotingInfo((prev) => ({
@@ -46,26 +52,58 @@ const StickerVoting = (props: StickerVotingProps) => {
     }
   };
 
+  const handleCancelSticker = (e: React.MouseEvent<SVGSVGElement>) => {
+    const stickerTarget = e.currentTarget as SVGSVGElement;
+    const clickStickerIdx = Number(stickerTarget.dataset.sticker);
+
+    if (0 <= clickStickerIdx && clickStickerIdx <= 2) {
+      setStickerVotingInfo((prev) => ({
+        ...prev,
+        location: [
+          ...stickerList.map((sticker, idx) => (idx === clickStickerIdx ? { ...sticker, isDelete: true } : sticker)),
+        ],
+      }));
+      toggle();
+    }
+  };
+
+  const handleStickerCancel = () => {
+    setStickerVotingInfo((prev) => ({
+      ...prev,
+      location: [...stickerList.filter((sticker) => !sticker.isDelete && sticker)],
+    }));
+    toggle();
+  };
+
   return (
-    <StStickerVotingWrapper>
-      <article>
-        <StStickerImg
-          onLoad={handleImgSize}
-          src={pictureInfo?.url}
-          ref={stickerImgRef}
-          alt="selected_img"
-          onClick={handleAttachSticker}
-        />
-        {!isStickerGuide &&
-          imgViewInfo &&
-          imgInfo &&
-          stickerList.map((sticker, idx) => (
-            <StEmojiIcon key={`sticker.x${idx}`} location={setStickerLocationData(sticker, imgViewInfo, imgInfo)}>
-              {STICKER_LIST[emoji].icon((54 * imgViewInfo.width) / 390)}
-            </StEmojiIcon>
-          ))}
-      </article>
-    </StStickerVotingWrapper>
+    <>
+      <Modal
+        isShowing={isShowing}
+        message="정말로 스티커를 삭제하시겠습니까?"
+        handleHide={toggle}
+        handleConfirm={handleStickerCancel}
+      />
+      <StStickerVotingWrapper>
+        <article>
+          <StStickerImg
+            onLoad={handleImgSize}
+            src={pictureInfo?.url}
+            ref={stickerImgRef}
+            alt="selected_img"
+            onClick={handleAttachSticker}
+          />
+          {!isStickerGuide &&
+            imgViewInfo &&
+            imgInfo &&
+            stickerList.map((sticker, idx) => (
+              <StEmojiIcon key={`sticker.x${idx}`} location={setStickerLocationData(sticker, imgViewInfo, imgInfo)}>
+                {STICKER_LIST[emoji].icon((54 * imgViewInfo.width) / 390)}
+                <IcCancel onClick={handleCancelSticker} data-sticker={`${idx}`} />
+              </StEmojiIcon>
+            ))}
+        </article>
+      </StStickerVotingWrapper>
+    </>
   );
 };
 
@@ -109,5 +147,14 @@ const StEmojiIcon = styled.div<{ location: StickerLocation }>`
 
     transform-origin: 50% 50%;
     transform: ${({ location }) => `rotate(${location.degRate}deg)`};
+
+    :last-child {
+      display: none;
+    }
+  }
+  &:hover {
+    & > svg:last-child {
+      display: block;
+    }
   }
 `;

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -63,6 +63,7 @@ export interface StickerLocation {
   x: number;
   y: number;
   degRate: number;
+  isDelete?: boolean;
 }
 export interface PlayerStickerInfo {
   pictureId: number;


### PR DESCRIPTION
## 🔥 Related Issues
resolved #134 

## 💜 작업 내용
- [x] 스티커 호버시 x
- [x] 스티커 x클릭시 삭제

## ✅ PR Point
> 여러분들이 만들어준 modal 컴포넌트를 활용해 스티커 삭제 기능을 구현하였습니다 ㅎㅎ

> ## types/vote.ts
기존의 스티커 부착 타입에 isDelete라는 타입을 두어 삭제를 결정하도록 했습니다

```typescript
export interface StickerLocation {
  x: number;
  y: number;
  degRate: number;
  isDelete?: boolean;
}
```


> ### ✅ handleDeleteSticker
삭제 아이콘을 누르면 해당 스티커의 isDelete를 true로 바꿔주었습니다!

```typescript
  const handleDeleteSticker = (e: React.MouseEvent<SVGSVGElement>) => {
    const stickerTarget = e.currentTarget as SVGSVGElement;
    const clickStickerIdx = Number(stickerTarget.dataset.sticker);

    if (0 <= clickStickerIdx && clickStickerIdx <= 2) {
      setStickerVotingInfo((prev) => ({
        ...prev,
        location: [
          ...stickerList.map((sticker, idx) => (idx === clickStickerIdx ? { ...sticker, isDelete: true } : sticker)),
        ],
      }));
      toggle();
    }
  };

<IcCancel onClick={handleDeleteSticker} data-sticker={`${idx}`} />
```

> ## 📄 components/Voting/player/StickerVoting.tsx
스티커 부착시, 삭제값을 기본으로 false로 지정하고 모달 이벤트를 활용해 isDelete값이 true인 스티커를 필터링 하였습니다!


```typescript
const newSticker: StickerLocation = {
          x: Math.round((((offsetX - 27) * imgInfo.width) / imgViewInfo.width) * 100) / 100,
          y: Math.round((((offsetY - 27) * imgInfo.height) / imgViewInfo.height) * 100) / 100,
          degRate: Math.round((Math.random() * 250 - 115) * 100) / 100,
          isDelete: false,
        };


const handleStickerCancel = () => {
    setStickerVotingInfo((prev) => ({
      ...prev,
      location: [...stickerList.filter((sticker) => !sticker.isDelete && sticker)],
    }));
    toggle();
  };
```




## 👀 스크린샷 / GIF / 링크

https://user-images.githubusercontent.com/79238676/214796817-1e8edd35-9842-4b66-bd9a-28a5a78a6676.mov


## 📚 Reference
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)
