### PR TITLE
[Maker Voting] 이미지 용량 리팩토링

### DIFF
--- a/src/components/Layout/maker/MakerVotingLayout.tsx
+++ b/src/components/Layout/maker/MakerVotingLayout.tsx
@@ -8,8 +8,6 @@ import { IcClose } from '../../../asset/icon';
 import useModal from '../../../lib/hooks/useModal';
 import { votingImageState } from '../../../recoil/maker/atom';
 import { setCroppedImg } from '../../../utils/setCroppedImg';
-import { setDataURLtoFile } from '../../../utils/setDataURLtoFile';
-import { setImgCompress } from '../../../utils/setImgCompress';
 import Modal from '../../common/Modal';
 import { ImageCrop, ImageInput, TitleInput } from '../../Voting/maker';
 import HeaderLayout from '../HeaderLayout';
@@ -26,7 +24,7 @@ const MakerVotingLayout = () => {
     firstToggle: true,
     secondToggle: true,
   });
-  const [croppedImage, setCroppedImage] = useState(null);
+
   const [votingForm, setVotingForm] = useRecoilState(votingImageState);
   const [rotation, setRotation] = useState(0);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | undefined>();
@@ -40,41 +38,20 @@ const MakerVotingLayout = () => {
   }, []);
 
   const handleShowCroppedImage = useCallback(async () => {
+    setIsCropToggle({ firstCrop: false, secondCrop: false });
+    setIsToggle({ firstToggle: true, secondToggle: true });
+
     if (firstCrop) {
       try {
-        const crop = await setCroppedImg(firstImageUrl, croppedAreaPixels, rotation);
-        if (crop) {
-          const baseToFile = setDataURLtoFile(crop, 'file') as File;
-          const reader = new FileReader();
-          const compressedImg = (await setImgCompress(baseToFile)) as File;
-          reader.readAsDataURL(compressedImg);
-          reader.onloadend = () => {
-            const base64data = reader.result as string;
-            setVotingForm({ ...votingForm, firstImageUrl: base64data });
-            setCroppedImage(croppedImage);
-            setIsCropToggle({ ...isCropToggle, firstCrop: false });
-            setIsToggle({ ...isToggle, firstToggle: !firstToggle });
-          };
-        }
+        const crop = (await setCroppedImg(firstImageUrl, croppedAreaPixels, rotation)) as string;
+        setVotingForm({ ...votingForm, firstImageUrl: crop });
       } catch (e) {
         console.error(e);
       }
     } else {
       try {
-        const crop = await setCroppedImg(secondImageUrl, croppedAreaPixels, rotation);
-        if (crop) {
-          const baseToFile = setDataURLtoFile(crop, 'file') as File;
-          const reader = new FileReader();
-          const compressedImg = (await setImgCompress(baseToFile)) as File;
-          reader.readAsDataURL(compressedImg);
-          reader.onloadend = () => {
-            const base64data = reader.result as string;
-            setVotingForm({ ...votingForm, secondImageUrl: base64data });
-            setCroppedImage(croppedImage);
-            setIsCropToggle({ ...isCropToggle, secondCrop: false });
-            setIsToggle({ ...isToggle, secondToggle: !secondToggle });
-          };
-        }
+        const crop = (await setCroppedImg(secondImageUrl, croppedAreaPixels, rotation)) as string;
+        setVotingForm({ ...votingForm, secondImageUrl: crop });
       } catch (e) {
         console.error(e);
       }

--- a/src/components/Voting/maker/ImageInput.tsx
+++ b/src/components/Voting/maker/ImageInput.tsx
@@ -96,9 +96,8 @@ const ImageInput = (props: ImageInputProps) => {
       imageData.append('title', title);
     }
     const response = await postImage(imageData);
-
-    if (response === 200) {
-      navigate('/share', { state: response });
+    if (response.status === 200) {
+      navigate('/share', { state: response.data });
       setVotingForm({
         title: '',
         firstImageUrl: '',

--- a/src/components/Voting/maker/ImageInput.tsx
+++ b/src/components/Voting/maker/ImageInput.tsx
@@ -4,12 +4,10 @@ import { useRecoilState } from 'recoil';
 import styled, { css } from 'styled-components';
 
 import { IcCropImg, IcImageAdd, IcModify, IcRemoveImg } from '../../../asset/icon';
-import { client } from '../../../lib/axios';
+import { postImage } from '../../../lib/api/voting';
 import { votingImageState } from '../../../recoil/maker/atom';
 import { setDataURLtoFile } from '../../../utils/setDataURLtoFile';
 import { setImgCompress } from '../../../utils/setImgCompress';
-
-const ACCESS_TOKEN = localStorage.getItem('accessToken');
 
 type ToggleProps = {
   firstToggle: boolean;
@@ -21,6 +19,7 @@ interface ImageInputProps {
   handleToggleModify: (e: React.MouseEvent<HTMLButtonElement>) => void;
   isToggle: ToggleProps;
 }
+
 const ImageInput = (props: ImageInputProps) => {
   const { handleCropImageToggle, handleToggleModify, isToggle } = props;
 
@@ -97,15 +96,10 @@ const ImageInput = (props: ImageInputProps) => {
       imageData.append('title', title);
     }
 
-    const response = await client.post(`/vote`, imageData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-        Authorization: `Bearer ${ACCESS_TOKEN}`,
-      },
-    });
+    const response = await postImage(imageData);
 
-    if (response.data.status === 200) {
-      navigate('/share', { state: response.data.data });
+    if (response === 200) {
+      navigate('/share', { state: response });
       setVotingForm({
         title: '',
         firstImageUrl: '',

--- a/src/components/Voting/maker/ImageInput.tsx
+++ b/src/components/Voting/maker/ImageInput.tsx
@@ -95,7 +95,6 @@ const ImageInput = (props: ImageInputProps) => {
       imageData.append('file', secondImgToFile);
       imageData.append('title', title);
     }
-
     const response = await postImage(imageData);
 
     if (response === 200) {

--- a/src/components/Voting/maker/TitleInput.tsx
+++ b/src/components/Voting/maker/TitleInput.tsx
@@ -31,6 +31,7 @@ const StTitleInput = styled.textarea`
   outline: none;
 
   text-align: center;
+  resize: none;
 
   ${({ theme }) => theme.fonts.Pic_Title2_Pretendard_SemiBold_20};
 

--- a/src/lib/api/voting.ts
+++ b/src/lib/api/voting.ts
@@ -3,6 +3,8 @@ import { AxiosResponse } from 'axios';
 import { client } from '../axios';
 import { PlayerStickerInfo, VoteResultData } from './../../types/vote';
 
+const ACCESS_TOKEN = localStorage.getItem('accessToken');
+
 export const patchCurrentVoteData = async (voteid: string | undefined) => {
   const res = await client.patch(`/vote/close/${voteid}`);
   return res;
@@ -28,6 +30,20 @@ export const postStickerData = async (stickerInfo: PlayerStickerInfo) => {
   try {
     const { data } = await client.post('/sticker', stickerInfo);
     return data;
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+export const postImage = async (imageData: FormData) => {
+  try {
+    const data = await client.post(`/vote`, imageData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: `Bearer ${ACCESS_TOKEN}`,
+      },
+    });
+    return data.data.status;
   } catch (e) {
     console.error(e);
   }

--- a/src/lib/api/voting.ts
+++ b/src/lib/api/voting.ts
@@ -43,7 +43,7 @@ export const postImage = async (imageData: FormData) => {
         Authorization: `Bearer ${ACCESS_TOKEN}`,
       },
     });
-    return data.data.status;
+    return data.data;
   } catch (e) {
     console.error(e);
   }

--- a/src/utils/setImgCompress.ts
+++ b/src/utils/setImgCompress.ts
@@ -2,7 +2,7 @@ import imageCompression from 'browser-image-compression';
 
 export const setImgCompress = async (fileSrc: File) => {
   const options = {
-    maxSizeMB: 5,
+    maxSizeMB: 1.5,
     maxWidthOrHeight: 1920,
     useWebWorker: true,
   };


### PR DESCRIPTION
## 🔥 Related Issues
resolved #136 

## 💜 작업 내용
- [x] ~ 이미지 용량 처리 리팩토링을 했습니다.
- [x] ~ 필요없는 코드를 삭제했습니다. 

## ✅ PR Point
- 이전코드에서 불필요하게 용량을 압축하는 부분이 있어 삭제했습니다
- 수정버튼 토글에 대한 처리를 굳이 첫번째 사진을 눌렀을때 / 두번째 사진을 눌렀을때 구분을 할 필요가 없어서 한번에 처리해 주었습니다.

```javascript
 const handleShowCroppedImage = useCallback(async () => {
    setIsCropToggle({ firstCrop: false, secondCrop: false });
    setIsToggle({ firstToggle: true, secondToggle: true });

    if (firstCrop) {
      try {
        const crop = (await setCroppedImg(firstImageUrl, croppedAreaPixels, rotation)) as string;
        setVotingForm({ ...votingForm, firstImageUrl: crop });
      } catch (e) {
        console.error(e);
      }
    } else {
      try {
        const crop = (await setCroppedImg(secondImageUrl, croppedAreaPixels, rotation)) as string;
        setVotingForm({ ...votingForm, secondImageUrl: crop });
      } catch (e) {
        console.error(e);
      }
    }
  }, [croppedAreaPixels, rotation]);
```

- ```ImageInput.tsx``` 파일에서 두개의 컴포넌트 코드가 같지만,,, 그 안에 조건부가 너무 많이 들어가 있어 분리를 어떻게 해야할지 ,,,```ImageInput.tsx```파일 안에서만 사용하는 컴포넌트인데 굳이 분리를 해줘야할지 고민입니당,,, ㅜㅜ

- 사실 indexeddb를 통해 용량 제한 없이 이미지를 저장하는 방식도 생각해봤는데 어차피 클라에서 이미지 압축을 안하더라도 서버에서 해야하는 상황이기 때문에(서버에서 압축을 진행하면 색감이 달라지는 문제가 있더라구요)그래서 일단 최대한 화질저하가 안되는 선에서 압축을 진행했습니다.  글고 사실 indexeddb 처음 사용해봐서 아직 어버버 되는 이슈도 있어서 공부를 하고 생각도 해보겠습니다!_!

