### PR TITLE
[ Home ] Footer 구현

### DIFF
--- a/src/components/Home/Footer.tsx
+++ b/src/components/Home/Footer.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Footer = () => <div></div>;
+
+export default Footer;

--- a/src/components/Home/Footer.tsx
+++ b/src/components/Home/Footer.tsx
@@ -1,5 +1,17 @@
 import React from 'react';
+import styled from 'styled-components';
 
-const Footer = () => <div></div>;
+const Footer = () => (
+  <>
+    <StFooterWrapper></StFooterWrapper>
+  </>
+);
 
 export default Footer;
+
+const StFooterWrapper = styled.footer`
+  width: 100%;
+  height: 21.3rem;
+
+  background-color: ${({ theme }) => theme.colors.Pic_Color_Gray_5};
+`;

--- a/src/components/Home/Footer.tsx
+++ b/src/components/Home/Footer.tsx
@@ -1,17 +1,70 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const Footer = () => (
-  <>
-    <StFooterWrapper></StFooterWrapper>
-  </>
-);
+const Footer = () => {
+  const footerLinkAddress = [
+    'https://trusted-fir-e0c.notion.site/8040a51be7c74c7babf71d4ae344e162',
+    'https://trusted-fir-e0c.notion.site/9df42e8f5c7246adb74027814a5c0cc9',
+    'https://www.notion.so/Team-Pic-me-e24dfca43b6b4ed296556f835e7662eb',
+  ];
+
+  return (
+    <StFooterWrapper>
+      <StLeftSection>
+        <p onClick={() => window.open(footerLinkAddress[0])}>이용약관</p>
+        <p onClick={() => window.open(footerLinkAddress[1])}>개인정보수집이용</p>
+      </StLeftSection>
+      <StRightSection>
+        <span>Contact</span>
+        <p>with.picme@gmail.com</p>
+        <span>Team</span>
+        <p onClick={() => window.open(footerLinkAddress[2])}>공식 노션 바로가기</p>
+        <span>Instagram</span>
+        <p>@official_pic.me</p>
+      </StRightSection>
+    </StFooterWrapper>
+  );
+};
 
 export default Footer;
 
 const StFooterWrapper = styled.footer`
+  display: flex;
+
   width: 100%;
   height: 21.3rem;
+  padding: 3.5rem 3.1rem;
 
+  color: #5c5c5c;
   background-color: ${({ theme }) => theme.colors.Pic_Color_Gray_5};
+`;
+
+const StLeftSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
+  gap: 3rem;
+
+  > p {
+    ${({ theme }) => theme.fonts.Pic_Body1_Pretendard_Medium_16};
+  }
+`;
+
+const StRightSection = styled.section`
+  flex: 1;
+
+  > span {
+    ${({ theme }) => theme.fonts.Pic_Body2_Pretendard_Bold_16};
+  }
+
+  > p {
+    padding-bottom: 1.3rem;
+
+    font-family: 'Pretendard';
+    font-style: normal;
+    font-weight: 400;
+    font-size: 1.4rem;
+    line-height: 1.7rem;
+  }
 `;

--- a/src/components/Home/Footer.tsx
+++ b/src/components/Home/Footer.tsx
@@ -1,30 +1,28 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const Footer = () => {
-  const footerLinkAddress = [
-    'https://trusted-fir-e0c.notion.site/8040a51be7c74c7babf71d4ae344e162',
-    'https://trusted-fir-e0c.notion.site/9df42e8f5c7246adb74027814a5c0cc9',
-    'https://www.notion.so/Team-Pic-me-e24dfca43b6b4ed296556f835e7662eb',
-  ];
+const FOOTER_LINK_ADDRESS = [
+  'https://trusted-fir-e0c.notion.site/8040a51be7c74c7babf71d4ae344e162',
+  'https://trusted-fir-e0c.notion.site/9df42e8f5c7246adb74027814a5c0cc9',
+  'https://www.notion.so/Team-Pic-me-e24dfca43b6b4ed296556f835e7662eb',
+];
 
-  return (
-    <StFooterWrapper>
-      <StLeftSection>
-        <p onClick={() => window.open(footerLinkAddress[0])}>이용약관</p>
-        <p onClick={() => window.open(footerLinkAddress[1])}>개인정보수집이용</p>
-      </StLeftSection>
-      <StRightSection>
-        <span>Contact</span>
-        <p>with.picme@gmail.com</p>
-        <span>Team</span>
-        <p onClick={() => window.open(footerLinkAddress[2])}>공식 노션 바로가기</p>
-        <span>Instagram</span>
-        <p>@official_pic.me</p>
-      </StRightSection>
-    </StFooterWrapper>
-  );
-};
+const Footer = () => (
+  <StFooterWrapper>
+    <StLeftSection>
+      <p onClick={() => window.open(FOOTER_LINK_ADDRESS[0])}>이용약관</p>
+      <p onClick={() => window.open(FOOTER_LINK_ADDRESS[1])}>개인정보수집이용</p>
+    </StLeftSection>
+    <StRightSection>
+      <span>Contact</span>
+      <p>with.picme@gmail.com</p>
+      <span>Team</span>
+      <p onClick={() => window.open(FOOTER_LINK_ADDRESS[2])}>공식 노션 바로가기</p>
+      <span>Instagram</span>
+      <p>@official_pic.me</p>
+    </StRightSection>
+  </StFooterWrapper>
+);
 
 export default Footer;
 

--- a/src/components/Home/Footer.tsx
+++ b/src/components/Home/Footer.tsx
@@ -40,13 +40,11 @@ const StFooterWrapper = styled.footer`
 `;
 
 const StLeftSection = styled.section`
-  display: flex;
-  flex-direction: column;
   flex: 1;
 
-  gap: 3rem;
-
   > p {
+    padding-bottom: 3rem;
+
     ${({ theme }) => theme.fonts.Pic_Body1_Pretendard_Medium_16};
   }
 `;

--- a/src/components/Home/Hamburger.tsx
+++ b/src/components/Home/Hamburger.tsx
@@ -42,9 +42,6 @@ const Hamburger = (props: HamburgerProps) => {
             }}>
             라이브러리
           </StHamburgerMenu>
-          <StHamburgerMenu>
-            <a href="https://www.notion.so/Team-Pic-me-e24dfca43b6b4ed296556f835e7662eb">픽미 팀소개</a>
-          </StHamburgerMenu>
         </StHamburgerWrapper>
       </StOutsideHamburger>
     </>
@@ -73,7 +70,7 @@ const StHamburgerWrapper = styled.ul<{ isOpen?: boolean }>`
   left: 0;
 
   width: 100%;
-  height: 20.3rem;
+  height: 14.5rem;
 
   background-color: ${({ theme }) => theme.colors.Pic_Color_White};
 

--- a/src/components/Home/VoteList.tsx
+++ b/src/components/Home/VoteList.tsx
@@ -77,7 +77,7 @@ const StVoteListWrapper = styled.main`
   overflow-x: scroll;
   overflow-y: hidden;
 
-  padding-bottom: 19.3rem;
+  margin-bottom: 19.3rem;
   height: 15.4rem;
 
   cursor: pointer;
@@ -93,8 +93,7 @@ const StEmptyView = styled.main`
   justify-content: center;
   align-items: center;
 
-  margin-top: 5.1rem;
-  padding-bottom: 19.3rem;
+  margin: 5.1rem 0rem 19.3rem 0rem;
 
   > svg {
     width: 13.8rem;

--- a/src/components/Home/index.ts
+++ b/src/components/Home/index.ts
@@ -1,3 +1,4 @@
+export { default as Footer } from './Footer';
 export { default as Hamburger } from './Hamburger';
 export { default as Header } from './Header';
 export { default as Nav } from './Nav';

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -29,7 +29,6 @@ export const postKakaoSignIn = async (uid: number) => {
 };
 
 export const postKakaoSignUp = async (uid: number, username: string) => {
-  console.log(uid, username);
   const { data } = await client.post<AxiosResponse<UserTokenInfo>>('/auth/kakao', {
     uid,
     socialType: 'kakao',

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import { IcPlus } from '../asset/icon';
 import { Header, Nav, VoteList } from '../components/Home';
+import Footer from '../components/Home/Footer';
 import { votingImageState } from '../recoil/maker/atom';
 
 const Home = () => {
@@ -30,6 +31,7 @@ const Home = () => {
         </StMakerVoting>
       </StHomeWrapper>
       <VoteList />
+      <Footer />
     </>
   );
 };


### PR DESCRIPTION
## 🔥 Related Issues
resolved #163 

## 💜 작업 내용
- [x] 홈 화면 하단에 Footer 추가
- [x] 햄버거 메뉴에서 '픽미 팀소개' 제거

## ✅ PR Point
- 이용 약관, 개인정보수집이용, 공식 노션 바로가기 클릭 시 해당 노션 페이지가 새 창으로 열립니다.
- 기획에서 '홈 화면' 에만 footer가 노출되어야 한다고 해서, 라이브러리 등 다른 페이지에는 footer가 존재하지 않습니다.

## 👀 스크린샷 / GIF / 링크
<img width="211" alt="스크린샷 2023-02-20 오후 2 29 37" src="https://user-images.githubusercontent.com/73213437/220018126-b992a571-6f46-48fd-83e1-b5078771ebda.png"> <img width="209" alt="스크린샷 2023-02-20 오후 2 34 43" src="https://user-images.githubusercontent.com/73213437/220018138-cb735227-15eb-4646-b345-9d75261959a7.png">

