### PR TITLE
[Refactor]  이미지 삽입 공통 컴포넌트로 분리

### DIFF
--- a/src/components/Voting/maker/ImageInput.tsx
+++ b/src/components/Voting/maker/ImageInput.tsx
@@ -3,11 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import styled, { css } from 'styled-components';
 
-import { IcCropImg, IcImageAdd, IcModify, IcRemoveImg } from '../../../asset/icon';
 import { postImage } from '../../../lib/api/voting';
 import { votingImageState } from '../../../recoil/maker/atom';
 import { setDataURLtoFile } from '../../../utils/setDataURLtoFile';
 import { setImgCompress } from '../../../utils/setImgCompress';
+import ImageForm from '../../common/ImageForm';
 
 type ToggleProps = {
   firstToggle: boolean;
@@ -109,60 +109,26 @@ const ImageInput = (props: ImageInputProps) => {
   return (
     <>
       <StImageInputWrapper>
-        {firstImageUrl ? (
-          <StImageTextBlock>
-            <StImage src={firstImageUrl} alt="첫번째 이미지" />
-            {firstToggle ? (
-              <StModifyImageButton type="button" value="firstModify" onClick={handleToggleModify}>
-                <IcModify />
-              </StModifyImageButton>
-            ) : (
-              <StModifyBlock>
-                <StModifyDepthBtn type="button" value="firstRemove" onClick={handleRemoveImg}>
-                  <IcRemoveImg />
-                </StModifyDepthBtn>
-                <StModifyDepthBtn type="button" value="firstCrop" onClick={handleCropImageToggle}>
-                  <IcCropImg />
-                </StModifyDepthBtn>
-              </StModifyBlock>
-            )}
-          </StImageTextBlock>
-        ) : (
-          <StImageInputLabel>
-            <StImageInput type="file" name="firstImg" accept="image/*" onChange={handleReadFileUrl} />
-            <StImageTextBlock>
-              <IcImageAdd />
-              <StImageText>여기에 사진을 넣어주세요!</StImageText>
-            </StImageTextBlock>
-          </StImageInputLabel>
-        )}
-        {secondImageUrl ? (
-          <StImageTextBlock>
-            <StImage src={secondImageUrl} alt="두번째 이미지" />
-            {secondToggle ? (
-              <StModifyImageButton type="button" value="secondModify" onClick={handleToggleModify}>
-                <IcModify />
-              </StModifyImageButton>
-            ) : (
-              <StModifyBlock>
-                <StModifyDepthBtn type="button" value="secondRemove" onClick={handleRemoveImg}>
-                  <IcRemoveImg />
-                </StModifyDepthBtn>
-                <StModifyDepthBtn type="button" value="secondCrop" onClick={handleCropImageToggle}>
-                  <IcCropImg />
-                </StModifyDepthBtn>
-              </StModifyBlock>
-            )}
-          </StImageTextBlock>
-        ) : (
-          <StImageInputLabel>
-            <StImageInput type="file" name="secondImg" accept="image/*" onChange={handleReadFileUrl} />
-            <StImageTextBlock>
-              <IcImageAdd />
-              <StImageText>여기에 사진을 넣어주세요!</StImageText>
-            </StImageTextBlock>
-          </StImageInputLabel>
-        )}
+        <ImageForm
+          imageUrl={firstImageUrl}
+          alt="첫번째 이미지"
+          toggle={firstToggle}
+          handleToggle={handleToggleModify}
+          handleRemove={handleRemoveImg}
+          handleCrop={handleCropImageToggle}
+          handleReadFileUrl={handleReadFileUrl}
+          name="firstImg"
+        />
+        <ImageForm
+          imageUrl={secondImageUrl}
+          alt="두번째 이미지"
+          toggle={secondToggle}
+          handleToggle={handleToggleModify}
+          handleRemove={handleRemoveImg}
+          handleCrop={handleCropImageToggle}
+          handleReadFileUrl={handleReadFileUrl}
+          name="secondImg"
+        />
         <StImageSubmitButton type="submit" isComplete={isComplete} disabled={!isComplete} onClick={handlePostImage}>
           투표 만들기 완료
         </StImageSubmitButton>
@@ -178,51 +144,6 @@ const StImageInputWrapper = styled.section`
 
   width: 100%;
   margin-top: 4.1rem;
-`;
-const StImageInputLabel = styled.label`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-
-  width: 100%;
-  height: 52rem;
-  margin-bottom: 2rem;
-
-  border-radius: 1.2rem;
-  background-color: ${({ theme }) => theme.colors.Pic_Color_Gray_5};
-
-  cursor: pointer;
-`;
-const StImage = styled.img`
-  width: 100%;
-  height: 100%;
-
-  border-radius: 1.2rem;
-
-  object-fit: cover;
-`;
-const StImageTextBlock = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  position: relative;
-
-  width: 100%;
-  height: 52rem;
-  margin-bottom: 2rem;
-
-  overflow: hidden;
-`;
-const StImageText = styled.span`
-  margin-top: 2.827rem;
-
-  color: ${({ theme }) => theme.colors.Pic_Color_Gray_3};
-  ${({ theme }) => theme.fonts.Pic_Body1_Pretendard_Medium_16};
-`;
-const StImageInput = styled.input`
-  display: none;
 `;
 const StImageSubmitButton = styled.button<{ isComplete: boolean }>`
   width: 100%;
@@ -246,48 +167,4 @@ const StImageSubmitButton = styled.button<{ isComplete: boolean }>`
       : css`
           background-color: ${({ theme }) => theme.colors.Pic_Color_Gray_4};
         `}
-`;
-const StModifyImageButton = styled.button`
-  position: absolute;
-  right: 2.1rem;
-  bottom: 2.1rem;
-
-  width: 6rem;
-  height: 6rem;
-
-  border: none;
-  border-radius: 50%;
-  background-color: ${({ theme }) => theme.colors.Pic_Color_Coral};
-
-  cursor: pointer;
-  svg {
-    pointer-events: none;
-  }
-`;
-const StModifyBlock = styled.div`
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-  flex-direction: column;
-  position: absolute;
-  right: 2.1rem;
-  bottom: 2.1rem;
-
-  width: 6rem;
-  height: 12rem;
-
-  border-radius: 6rem;
-  background-color: ${({ theme }) => theme.colors.Pic_Color_Coral};
-
-  z-index: 5;
-`;
-const StModifyDepthBtn = styled.button`
-  border: none;
-  background-color: ${({ theme }) => theme.colors.Pic_Color_Coral};
-
-  outline: none;
-  cursor: pointer;
-  svg {
-    pointer-events: none;
-  }
 `;

--- a/src/components/common/ImageForm.tsx
+++ b/src/components/common/ImageForm.tsx
@@ -1,0 +1,136 @@
+import styled from 'styled-components';
+
+import { IcCropImg, IcImageAdd, IcModify, IcRemoveImg } from '../../asset/icon';
+
+interface ImageFormProps {
+  imageUrl: string;
+  alt: string;
+  toggle: boolean;
+  name: string;
+  handleToggle: React.MouseEventHandler;
+  handleRemove: React.MouseEventHandler;
+  handleCrop: React.MouseEventHandler;
+  handleReadFileUrl: React.ChangeEventHandler;
+}
+const ImageForm = (props: ImageFormProps) => {
+  const { imageUrl, alt, toggle, handleToggle, handleRemove, handleCrop, handleReadFileUrl, name } = props;
+
+  return imageUrl ? (
+    <StImageTextBlock>
+      <StImage src={imageUrl} alt={alt} />
+      {toggle ? (
+        <StModifyImageButton type="button" value="modify" onClick={handleToggle}>
+          <IcModify />
+        </StModifyImageButton>
+      ) : (
+        <StModifyBlock>
+          <StModifyDepthBtn type="button" value="remove" onClick={handleRemove}>
+            <IcRemoveImg />
+          </StModifyDepthBtn>
+          <StModifyDepthBtn type="button" value="crop" onClick={handleCrop}>
+            <IcCropImg />
+          </StModifyDepthBtn>
+        </StModifyBlock>
+      )}
+    </StImageTextBlock>
+  ) : (
+    <StImageInputLabel>
+      <StImageInput type="file" name={name} accept="image/*" onChange={handleReadFileUrl} />
+      <StImageTextBlock>
+        <IcImageAdd />
+        <StImageText>여기에 사진을 넣어주세요!</StImageText>
+      </StImageTextBlock>
+    </StImageInputLabel>
+  );
+};
+
+export default ImageForm;
+const StImageInputLabel = styled.label`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  width: 100%;
+  height: 52rem;
+  margin-bottom: 2rem;
+
+  border-radius: 1.2rem;
+  background-color: ${({ theme }) => theme.colors.Pic_Color_Gray_5};
+
+  cursor: pointer;
+`;
+const StImage = styled.img`
+  width: 100%;
+  height: 100%;
+
+  border-radius: 1.2rem;
+
+  object-fit: cover;
+`;
+const StImageInput = styled.input`
+  display: none;
+`;
+const StImageTextBlock = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  position: relative;
+
+  width: 100%;
+  height: 52rem;
+  margin-bottom: 2rem;
+
+  overflow: hidden;
+`;
+const StImageText = styled.span`
+  margin-top: 2.827rem;
+
+  color: ${({ theme }) => theme.colors.Pic_Color_Gray_3};
+  ${({ theme }) => theme.fonts.Pic_Body1_Pretendard_Medium_16};
+`;
+const StModifyImageButton = styled.button`
+  position: absolute;
+  right: 2.1rem;
+  bottom: 2.1rem;
+
+  width: 6rem;
+  height: 6rem;
+
+  border: none;
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.colors.Pic_Color_Coral};
+
+  cursor: pointer;
+  svg {
+    pointer-events: none;
+  }
+`;
+const StModifyBlock = styled.div`
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  flex-direction: column;
+  position: absolute;
+  right: 2.1rem;
+  bottom: 2.1rem;
+
+  width: 6rem;
+  height: 12rem;
+
+  border-radius: 6rem;
+  background-color: ${({ theme }) => theme.colors.Pic_Color_Coral};
+
+  z-index: 5;
+`;
+const StModifyDepthBtn = styled.button`
+  border: none;
+  background-color: ${({ theme }) => theme.colors.Pic_Color_Coral};
+
+  outline: none;
+  cursor: pointer;
+  svg {
+    pointer-events: none;
+  }
+`;


### PR DESCRIPTION
## 🔥 Related Issues
resolved #162 

## 💜 작업 내용
- [x] ~ 이미지 삽입 컴포넌트를 공통 컴포넌트로 분리

## ✅ PR Point
이미지 삽입에 관한 props (몇번째 사진, alt, 이미지 수정 버튼, 이미지 크롭 버튼, 이미지 삭제버튼, 이미지 미리보기)를 넘겨받아 처리해주었습니다.
```javascript
 const { imageUrl, alt, toggle, handleToggle, handleRemove, handleCrop, handleReadFileUrl, name } = props;

  return imageUrl ? (
    <StImageTextBlock>
      <StImage src={imageUrl} alt={alt} />
      {toggle ? (
        <StModifyImageButton type="button" value="modify" onClick={handleToggle}>
          <IcModify />
        </StModifyImageButton>
      ) : (
        <StModifyBlock>
          <StModifyDepthBtn type="button" value="remove" onClick={handleRemove}>
            <IcRemoveImg />
          </StModifyDepthBtn>
          <StModifyDepthBtn type="button" value="crop" onClick={handleCrop}>
            <IcCropImg />
          </StModifyDepthBtn>
        </StModifyBlock>
      )}
    </StImageTextBlock>
  ) : (
    <StImageInputLabel>
      <StImageInput type="file" name={name} accept="image/*" onChange={handleReadFileUrl} />
      <StImageTextBlock>
        <IcImageAdd />
        <StImageText>여기에 사진을 넣어주세요!</StImageText>
      </StImageTextBlock>
    </StImageInputLabel>
  );
```

 common 폴더에 있는 공통컴포넌트 방식을 사용했습니다. 조건에 따라 달라지는 state,ui가 많아 생각이 많았는데 더 좋은 방법이 있다면 마구마구 남겨주세요!
```javascript
 <ImageForm
          imageUrl={firstImageUrl}
          alt="첫번째 이미지"
          toggle={firstToggle}
          handleToggle={handleToggleModify}
          handleRemove={handleRemoveImg}
          handleCrop={handleCropImageToggle}
          handleReadFileUrl={handleReadFileUrl}
          name="firstImg"
 />
 <ImageForm
          imageUrl={secondImageUrl}
          alt="두번째 이미지"
          toggle={secondToggle}
          handleToggle={handleToggleModify}
          handleRemove={handleRemoveImg}
          handleCrop={handleCropImageToggle}
          handleReadFileUrl={handleReadFileUrl}
          name="secondImg"
 />
```
