### PR TITLE
[ Refactor ] 상태바 색상 동적 변경 기능 구현 및 햄버거 메뉴 리팩토링

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,8 @@
     <title>Pic.me</title>
     <meta
       name="viewport"
-      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" />
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, viewport-fit=cover" />
+    <meta id="status-bar" name="theme-color" content="FFFFFF" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="친구가 골라주는 나의 베스트 Pic!" />
     <meta name="keywords" content="친구가 골라주는 나의 베스트 Pic!" />

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -89,7 +89,7 @@ const StInput = styled.input`
   height: 6rem;
   margin-top: 1.4rem;
   padding-left: 1.9rem;
-  border: 1px solid ${({ theme }) => theme.colors.Pic_Color_Gray_4};
+  border: 0.1rem solid ${({ theme }) => theme.colors.Pic_Color_Gray_4};
   border-radius: 0.6rem;
   outline: none;
   ${({ theme }) => theme.fonts.Pic_Subtitle2_Pretendard_Medium_18};
@@ -110,7 +110,7 @@ const StAuthBtn = styled.button<{ isSignUp?: boolean }>`
   width: 100%;
   height: 6rem;
   border: none;
-  border-radius: 9px;
+  border-radius: 0.9rem;
   background-color: ${({ theme }) => theme.colors.Pic_Color_Gray_Black};
   color: white;
   ${({ theme }) => theme.fonts.Pic_Body1_Pretendard_Medium_16};

--- a/src/components/Auth/MemberInfo.tsx
+++ b/src/components/Auth/MemberInfo.tsx
@@ -57,7 +57,7 @@ const MemberInfo = () => {
         {}
         <p>{email}</p>
         <div>
-          <button type="button" onClick={() => toggle()}>
+          <button type="button" onClick={toggle}>
             회원 탈퇴하기
           </button>
           <Modal

--- a/src/components/Home/Footer.tsx
+++ b/src/components/Home/Footer.tsx
@@ -33,7 +33,7 @@ const StFooterWrapper = styled.footer`
   height: 21.3rem;
   padding: 3.5rem 3.1rem;
 
-  color: #5c5c5c;
+  color: ${({ theme }) => theme.colors.Pic_Color_Gray_2};
   background-color: ${({ theme }) => theme.colors.Pic_Color_Gray_5};
 `;
 
@@ -51,16 +51,12 @@ const StRightSection = styled.section`
   flex: 1;
 
   > span {
-    ${({ theme }) => theme.fonts.Pic_Body2_Pretendard_Bold_16};
+    ${({ theme }) => theme.fonts.Pic_Noto_SB_Title_2};
   }
 
   > p {
     padding-bottom: 1.3rem;
 
-    font-family: 'Pretendard';
-    font-style: normal;
-    font-weight: 400;
-    font-size: 1.4rem;
-    line-height: 1.7rem;
+    ${({ theme }) => theme.fonts.Pic_Noto_M_Subtitle_5};
   }
 `;

--- a/src/components/Home/Hamburger.tsx
+++ b/src/components/Home/Hamburger.tsx
@@ -10,24 +10,22 @@ const Hamburger = React.forwardRef<HTMLUListElement, HamburgerProps>(({ isOpen }
   const navigate = useNavigate();
 
   return (
-    <>
-      <StOutsideHamburger isOpen={isOpen}>
-        <StHamburgerWrapper isOpen={isOpen} ref={ref}>
-          <StHamburgerMenu
-            onClick={() => {
-              navigate('/mypage');
-            }}>
-            회원 정보
-          </StHamburgerMenu>
-          <StHamburgerMenu
-            onClick={() => {
-              navigate('/library');
-            }}>
-            라이브러리
-          </StHamburgerMenu>
-        </StHamburgerWrapper>
-      </StOutsideHamburger>
-    </>
+    <StOutsideHamburger isOpen={isOpen}>
+      <StHamburgerWrapper isOpen={isOpen} ref={ref}>
+        <StHamburgerMenu
+          onClick={() => {
+            navigate('/mypage');
+          }}>
+          회원 정보
+        </StHamburgerMenu>
+        <StHamburgerMenu
+          onClick={() => {
+            navigate('/library');
+          }}>
+          라이브러리
+        </StHamburgerMenu>
+      </StHamburgerWrapper>
+    </StOutsideHamburger>
   );
 });
 Hamburger.displayName = 'Hamburger';

--- a/src/components/Home/Hamburger.tsx
+++ b/src/components/Home/Hamburger.tsx
@@ -6,57 +6,40 @@ export interface HamburgerProps {
   isOpen: boolean;
 }
 
-const Hamburger = React.forwardRef<HTMLUListElement, HamburgerProps>(({ isOpen }, ref) => {
+const Hamburger = ({ isOpen }: HamburgerProps) => {
   const navigate = useNavigate();
 
   return (
-    <StOutsideHamburger isOpen={isOpen}>
-      <StHamburgerWrapper isOpen={isOpen} ref={ref}>
-        <StHamburgerMenu
-          onClick={() => {
-            navigate('/mypage');
-          }}>
-          회원 정보
-        </StHamburgerMenu>
-        <StHamburgerMenu
-          onClick={() => {
-            navigate('/library');
-          }}>
-          라이브러리
-        </StHamburgerMenu>
-      </StHamburgerWrapper>
-    </StOutsideHamburger>
+    <StHamburgerWrapper isOpen={isOpen}>
+      <StHamburgerMenu
+        onClick={() => {
+          navigate('/mypage');
+        }}>
+        회원 정보
+      </StHamburgerMenu>
+      <StHamburgerMenu
+        onClick={() => {
+          navigate('/library');
+        }}>
+        라이브러리
+      </StHamburgerMenu>
+    </StHamburgerWrapper>
   );
-});
-Hamburger.displayName = 'Hamburger';
+};
 
 export default Hamburger;
-
-const StOutsideHamburger = styled.div<{ isOpen?: boolean }>`
-  display: ${(props) => (props.isOpen ? 'block' : 'none')};
-  position: fixed;
-  top: 9rem;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  z-index: 1;
-
-  width: 100%;
-  height: 100%;
-
-  background-color: ${(props) => (props.isOpen ? 'rgba(0, 0, 0, 0.7)' : 'rgba(0, 0, 0, 0)')};
-`;
 
 const StHamburgerWrapper = styled.ul<{ isOpen?: boolean }>`
   position: fixed;
   left: 0;
+  z-index: -10;
 
   width: 100%;
   height: 14.5rem;
 
   background-color: ${({ theme }) => theme.colors.Pic_Color_White};
 
-  transition: 0.5s ease;
+  transition: 0.3s ease;
 
   ${({ isOpen }) =>
     isOpen
@@ -64,7 +47,7 @@ const StHamburgerWrapper = styled.ul<{ isOpen?: boolean }>`
           top: 8.8rem;
         `
       : css`
-          top: -200%;
+          top: -100%;
 
           transition: 2s ease;
         `}
@@ -72,23 +55,15 @@ const StHamburgerWrapper = styled.ul<{ isOpen?: boolean }>`
 
 const StHamburgerMenu = styled.li`
   padding: 2rem 2.8rem;
+
   color: ${({ theme }) => theme.colors.Pic_Color_Gray_2};
-  font-family: 'Pretendard', sans-serif;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 1.8rem;
-  line-height: 2.1rem;
+  ${({ theme }) => theme.fonts.Pic_Subtitle2_Pretendard_Medium_18};
 
   & > a {
     display: block;
 
     color: ${({ theme }) => theme.colors.Pic_Color_Gray_2};
-    font-family: 'Pretendard', sans-serif;
-    font-style: normal;
-    font-weight: 500;
-    font-size: 1.8rem;
-    line-height: 2.1rem;
-    text-decoration: none;
+    ${({ theme }) => theme.fonts.Pic_Subtitle2_Pretendard_Medium_18};
   }
 
   cursor: pointer;

--- a/src/components/Home/Hamburger.tsx
+++ b/src/components/Home/Hamburger.tsx
@@ -1,35 +1,18 @@
-import React, { Dispatch, SetStateAction, useEffect, useRef } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
 export interface HamburgerProps {
   isOpen: boolean;
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
 }
 
-const Hamburger = (props: HamburgerProps) => {
-  const { isOpen, setIsOpen } = props;
-
-  const sidebarRef = useRef<HTMLElement>(null);
+const Hamburger = React.forwardRef<HTMLUListElement, HamburgerProps>(({ isOpen }, ref) => {
   const navigate = useNavigate();
-
-  const onClickOutSide = (event: Event) => {
-    if (!sidebarRef.current?.contains(event.target as Node)) {
-      setIsOpen(false);
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener('click', onClickOutSide, true);
-    return () => {
-      document.removeEventListener('click', onClickOutSide, true);
-    };
-  });
 
   return (
     <>
       <StOutsideHamburger isOpen={isOpen}>
-        <StHamburgerWrapper isOpen={isOpen}>
+        <StHamburgerWrapper isOpen={isOpen} ref={ref}>
           <StHamburgerMenu
             onClick={() => {
               navigate('/mypage');
@@ -46,7 +29,8 @@ const Hamburger = (props: HamburgerProps) => {
       </StOutsideHamburger>
     </>
   );
-};
+});
+Hamburger.displayName = 'Hamburger';
 
 export default Hamburger;
 

--- a/src/components/Home/Header.tsx
+++ b/src/components/Home/Header.tsx
@@ -14,7 +14,7 @@ const Header = () => {
         <StBannerImg>
           <IcBannerImg />
         </StBannerImg>
-        <StGuideBtn type="button" onClick={() => toggle()}>
+        <StGuideBtn type="button" onClick={toggle}>
           <p>픽미 사용방법 A부터 Z까지</p>
           <IcNextArrow />
         </StGuideBtn>

--- a/src/components/Home/Nav.tsx
+++ b/src/components/Home/Nav.tsx
@@ -1,19 +1,17 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import { IcClose, IcHamburger, IcHomeLogo } from '../../asset/icon';
 import useModal from '../../lib/hooks/useModal';
 import useOnClickOutside from '../../lib/hooks/useOnClickOutside';
 import { clearUserSession } from '../../lib/token';
-import { hamburgerState } from '../../recoil/maker/atom';
 import Modal from '../common/Modal';
 import Hamburger from './Hamburger';
 
 const Nav = () => {
   const { isShowing, toggle } = useModal();
-  const [hamburger, setHamburger] = useRecoilState(hamburgerState);
+  const [hamburger, setHamburger] = useState(false);
   const sidebarRef = useRef<HTMLUListElement>(null);
   const navigate = useNavigate();
 

--- a/src/components/Home/Nav.tsx
+++ b/src/components/Home/Nav.tsx
@@ -1,17 +1,20 @@
-import React, { useState } from 'react';
+import React, { useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import { IcClose, IcHamburger, IcHomeLogo } from '../../asset/icon';
 import useModal from '../../lib/hooks/useModal';
+import useOnClickOutside from '../../lib/hooks/useOnClickOutside';
 import { clearUserSession } from '../../lib/token';
+import { hamburgerState } from '../../recoil/maker/atom';
 import Modal from '../common/Modal';
 import Hamburger from './Hamburger';
 
 const Nav = () => {
   const { isShowing, toggle } = useModal();
-  const [isOpen, setIsOpen] = useState(false);
-
+  const [hamburger, setHamburger] = useRecoilState(hamburgerState);
+  const sidebarRef = useRef<HTMLUListElement>(null);
   const navigate = useNavigate();
 
   const handleLogout = async () => {
@@ -24,12 +27,19 @@ const Nav = () => {
   };
 
   const handleHamburger = () => {
-    setIsOpen((isOpen) => !isOpen);
+    setHamburger((hamburger) => !hamburger);
   };
 
   const handleReLoad = () => {
     window.location.reload();
   };
+
+  const handleClickOutside = (event: Event) => {
+    setHamburger(false);
+  };
+
+  useOnClickOutside({ ref: sidebarRef, handler: handleClickOutside });
+
   return (
     <>
       <StHomeNav>
@@ -47,10 +57,10 @@ const Nav = () => {
             handleConfirm={handleLogout}
           />
           <StHamburgerBtn type="button" onClick={handleHamburger}>
-            {isOpen ? <IcClose width="2.13rem" height="1.4rem" /> : <IcHamburger width="2.13rem" height="1.4rem" />}
+            {hamburger ? <IcClose /> : <IcHamburger />}
           </StHamburgerBtn>
         </StHamburgerWrapper>
-        <Hamburger isOpen={isOpen} setIsOpen={setIsOpen} />
+        <Hamburger isOpen={hamburger} ref={sidebarRef} />
       </StHomeNav>
     </>
   );
@@ -77,6 +87,7 @@ const StHomeNav = styled.nav`
 
 const StLogoBtn = styled.a`
   cursor: pointer;
+
   > svg {
     width: 11.1rem;
     height: 5.4rem;

--- a/src/components/Home/Nav.tsx
+++ b/src/components/Home/Nav.tsx
@@ -28,11 +28,7 @@ const Nav = () => {
     setHamburger((hamburger) => !hamburger);
   };
 
-  const handleReLoad = () => {
-    window.location.reload();
-  };
-
-  const handleClickOutside = (event: Event) => {
+  const handleClickOutside = () => {
     setHamburger(false);
   };
 
@@ -40,33 +36,54 @@ const Nav = () => {
 
   return (
     <>
-      <StHomeNav>
-        <StLogoBtn onClick={handleReLoad}>
-          <IcHomeLogo />
-        </StLogoBtn>
-        <StHamburgerWrapper>
-          <StLogoutBtn type="button" onClick={() => toggle()}>
-            로그아웃
-          </StLogoutBtn>
-          <Modal
-            isShowing={isShowing}
-            message="로그아웃 하시겠습니까?"
-            handleHide={toggle}
-            handleConfirm={handleLogout}
-          />
-          <StHamburgerBtn type="button" onClick={handleHamburger}>
-            {hamburger ? <IcClose /> : <IcHamburger />}
-          </StHamburgerBtn>
-        </StHamburgerWrapper>
-        <Hamburger isOpen={hamburger} ref={sidebarRef} />
-      </StHomeNav>
+      <StOutsideNav isOpen={hamburger} />
+      <StNavWrapper ref={sidebarRef}>
+        <StNavBar>
+          <StLogoBtn
+            onClick={() => {
+              window.location.reload();
+            }}>
+            <IcHomeLogo />
+          </StLogoBtn>
+          <StButtonWrapper>
+            <StLogoutBtn type="button" onClick={toggle}>
+              로그아웃
+            </StLogoutBtn>
+            <Modal
+              isShowing={isShowing}
+              message="로그아웃 하시겠습니까?"
+              handleHide={toggle}
+              handleConfirm={handleLogout}
+            />
+            <StHamburgerBtn type="button" onClick={handleHamburger}>
+              {hamburger ? <IcClose /> : <IcHamburger />}
+            </StHamburgerBtn>
+          </StButtonWrapper>
+        </StNavBar>
+        <Hamburger isOpen={hamburger} />
+      </StNavWrapper>
     </>
   );
 };
 
 export default Nav;
 
-const StHomeNav = styled.nav`
+const StOutsideNav = styled.div<{ isOpen?: boolean }>`
+  display: ${(props) => (props.isOpen ? 'block' : 'none')};
+  position: fixed;
+  top: 9rem;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  z-index: 1;
+
+  width: 100%;
+  height: 100%;
+
+  background-color: ${(props) => (props.isOpen ? 'rgba(0, 0, 0, 0.7)' : 'rgba(0, 0, 0, 0)')};
+`;
+
+const StNavWrapper = styled.nav`
   display: flex;
 
   justify-content: space-between;
@@ -83,6 +100,8 @@ const StHomeNav = styled.nav`
   background-color: ${({ theme }) => theme.colors.Pic_Color_White};
 `;
 
+const StNavBar = styled(StNavWrapper)``;
+
 const StLogoBtn = styled.a`
   cursor: pointer;
 
@@ -92,7 +111,7 @@ const StLogoBtn = styled.a`
   }
 `;
 
-const StHamburgerWrapper = styled.div`
+const StButtonWrapper = styled.div`
   display: flex;
   align-items: center;
   z-index: 100;

--- a/src/components/Signup/Nickname.tsx
+++ b/src/components/Signup/Nickname.tsx
@@ -143,7 +143,7 @@ const StInput = styled.input`
   margin-top: 1.4rem;
   padding-left: 7.14%;
 
-  border: 1px solid ${({ theme }) => theme.colors.Pic_Color_Gray_4};
+  border: 0.1rem solid ${({ theme }) => theme.colors.Pic_Color_Gray_4};
   border-radius: 0.6rem;
   outline: none;
   ${({ theme }) => theme.fonts.Pic_Subtitle2_Pretendard_Medium_18};

--- a/src/components/common/Router.tsx
+++ b/src/components/common/Router.tsx
@@ -2,7 +2,7 @@ import React, { lazy, Suspense } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
 
-import Loading from './Loading';
+import StatusBarForiOS from './StatusBarForiOS';
 
 const CurrentVoteDetail = lazy(() => import('../../pages/CurrentVoteDetail'));
 const Error404 = lazy(() => import('../../pages/Error404'));
@@ -28,6 +28,7 @@ const Router = () => (
   <BrowserRouter>
     <RecoilRoot>
       <Suspense>
+        <StatusBarForiOS />
         <Routes>
           <Route path="/" element={<Onboarding />} />
           <Route path="/login" element={<Login />} />
@@ -36,7 +37,6 @@ const Router = () => (
           <Route path="/current/vote/:voteid" element={<CurrentVoteDetail />} />
           <Route path="/myPage" element={<MemberInfo />} />
           <Route path="/library" element={<Library />} />
-          <Route path="/login" element={<Login />} />
           <Route path="/result/:voteId" element={<Result />} />
           <Route path="/share" element={<Share />} />
           <Route path="/makervoting" element={<MakerVoting />} />

--- a/src/components/common/StatusBarForiOS.tsx
+++ b/src/components/common/StatusBarForiOS.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import useStatusBarColor from '../../lib/hooks/useStatusBarColor';
+
+const StatusBarForiOS = () => {
+  useStatusBarColor();
+  return <></>;
+};
+
+export default StatusBarForiOS;

--- a/src/lib/hooks/useModal.ts
+++ b/src/lib/hooks/useModal.ts
@@ -1,9 +1,14 @@
 import { useState } from 'react';
 
-const useModal = () => {
+interface ModalState {
+  isShowing: boolean;
+  toggle: () => void;
+}
+
+const useModal = (): ModalState => {
   const [isShowing, setIsShowing] = useState(false);
 
-  const toggle = () => setIsShowing(!isShowing);
+  const toggle = () => setIsShowing((prev) => !prev);
 
   return {
     isShowing,

--- a/src/lib/hooks/useOnClickOutside.tsx
+++ b/src/lib/hooks/useOnClickOutside.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+interface useOnClickOutsideProps {
+  ref: React.RefObject<HTMLElement>;
+  handler: (event: Event) => void;
+}
+
+const useOnClickOutside = ({ ref, handler }: useOnClickOutsideProps) => {
+  useEffect(() => {
+    const listener = (event: Event) => {
+      const el = ref?.current;
+      if (!el || el.contains((event?.target as Node) || null)) {
+        return;
+      }
+
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+};
+
+export default useOnClickOutside;

--- a/src/lib/hooks/useOnClickOutside.tsx
+++ b/src/lib/hooks/useOnClickOutside.tsx
@@ -9,7 +9,7 @@ interface UseOnClickOutsideProps {
 
 const useOnClickOutside = ({ ref, handler }: UseOnClickOutsideProps) => {
   const handleClickOutside = (event: Event) => {
-    if (ref.current && event.target && ref.current.contains(event.target as Node)) {
+    if (ref.current && !ref.current.contains(event.target as Node)) {
       handler(event);
     }
   };

--- a/src/lib/hooks/useOnClickOutside.tsx
+++ b/src/lib/hooks/useOnClickOutside.tsx
@@ -1,29 +1,29 @@
-import { useEffect } from 'react';
+import { RefObject, useEffect } from 'react';
 
-interface useOnClickOutsideProps {
-  ref: React.RefObject<HTMLElement>;
+type Event = MouseEvent | TouchEvent;
+
+interface UseOnClickOutsideProps {
+  ref: RefObject<HTMLElement>;
   handler: (event: Event) => void;
 }
 
-const useOnClickOutside = ({ ref, handler }: useOnClickOutsideProps) => {
-  useEffect(() => {
-    const listener = (event: Event) => {
-      const el = ref?.current;
-      if (!el || el.contains((event?.target as Node) || null)) {
-        return;
-      }
-
+const useOnClickOutside = ({ ref, handler }: UseOnClickOutsideProps) => {
+  const handleClickOutside = (event: Event) => {
+    if (ref.current && event.target && ref.current.contains(event.target as Node)) {
       handler(event);
-    };
+    }
+  };
 
-    document.addEventListener('mousedown', listener);
-    document.addEventListener('touchstart', listener);
-
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
     return () => {
-      document.removeEventListener('mousedown', listener);
-      document.removeEventListener('touchstart', listener);
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
     };
   }, [ref, handler]);
+
+  return handleClickOutside;
 };
 
 export default useOnClickOutside;

--- a/src/lib/hooks/useStatusBarColor.tsx
+++ b/src/lib/hooks/useStatusBarColor.tsx
@@ -10,6 +10,7 @@ export const STATUS_BAR_COLOR = {
 export const STATUS_BAR_COLOR_USAGE = new Map([
   ['/', STATUS_BAR_COLOR.LANDING_PAGE],
   ['/login', STATUS_BAR_COLOR.AUTH_PAGE],
+  ['/signup', STATUS_BAR_COLOR.AUTH_PAGE],
   ['/mypage', STATUS_BAR_COLOR.AUTH_PAGE],
 ]);
 

--- a/src/lib/hooks/useStatusBarColor.tsx
+++ b/src/lib/hooks/useStatusBarColor.tsx
@@ -1,0 +1,31 @@
+import { useLayoutEffect, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const STATUS_BAR_COLOR = {
+  LANDING_PAGE: '#FF736E',
+  AUTH_PAGE: '#1E1F21',
+  GENERAL_PAGE: '#FFFFFF',
+};
+
+export const STATUS_BAR_COLOR_USAGE = new Map([
+  ['/', STATUS_BAR_COLOR.LANDING_PAGE],
+  ['/login', STATUS_BAR_COLOR.AUTH_PAGE],
+  ['/mypage', STATUS_BAR_COLOR.AUTH_PAGE],
+]);
+
+const useStatusBarColor = () => {
+  const location = useLocation();
+
+  const statusBarColor = useMemo(
+    () => STATUS_BAR_COLOR_USAGE.get(location.pathname) ?? STATUS_BAR_COLOR.GENERAL_PAGE,
+    [location],
+  );
+
+  useLayoutEffect(() => {
+    const metaElement = document.getElementById('status-bar');
+    if (!metaElement) return;
+    (metaElement as HTMLMetaElement).content = statusBarColor;
+  }, [statusBarColor]);
+};
+
+export default useStatusBarColor;

--- a/src/lib/hooks/useStatusBarColor.tsx
+++ b/src/lib/hooks/useStatusBarColor.tsx
@@ -2,7 +2,7 @@ import { useLayoutEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
 export const STATUS_BAR_COLOR = {
-  LANDING_PAGE: '#FF736E',
+  LANDING_PAGE: '#FF6A69',
   AUTH_PAGE: '#1E1F21',
   GENERAL_PAGE: '#FFFFFF',
 };
@@ -25,6 +25,9 @@ const useStatusBarColor = () => {
     const metaElement = document.getElementById('status-bar');
     if (!metaElement) return;
     (metaElement as HTMLMetaElement).content = statusBarColor;
+    // return () => {
+    //   (metaElement as HTMLMetaElement).content = STATUS_BAR_COLOR.GENERAL_PAGE;
+    // };
   }, [statusBarColor]);
 };
 

--- a/src/lib/hooks/useStatusBarColor.tsx
+++ b/src/lib/hooks/useStatusBarColor.tsx
@@ -25,9 +25,6 @@ const useStatusBarColor = () => {
     const metaElement = document.getElementById('status-bar');
     if (!metaElement) return;
     (metaElement as HTMLMetaElement).content = statusBarColor;
-    // return () => {
-    //   (metaElement as HTMLMetaElement).content = STATUS_BAR_COLOR.GENERAL_PAGE;
-    // };
   }, [statusBarColor]);
 };
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,8 +4,7 @@ import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import { IcPlus } from '../asset/icon';
-import { Header, Nav, VoteList } from '../components/Home';
-import Footer from '../components/Home/Footer';
+import { Footer, Header, Nav, VoteList } from '../components/Home';
 import { votingImageState } from '../recoil/maker/atom';
 
 const Home = () => {

--- a/src/recoil/maker/atom.ts
+++ b/src/recoil/maker/atom.ts
@@ -60,3 +60,8 @@ export const stickerResultState = atom<StickerResultInfo[]>({
   ],
   effects_UNSTABLE: [persistAtom],
 });
+
+export const hamburgerState = atom<boolean>({
+  key: 'hamburger',
+  default: false,
+});

--- a/src/recoil/maker/atom.ts
+++ b/src/recoil/maker/atom.ts
@@ -60,8 +60,3 @@ export const stickerResultState = atom<StickerResultInfo[]>({
   ],
   effects_UNSTABLE: [persistAtom],
 });
-
-export const hamburgerState = atom<boolean>({
-  key: 'hamburger',
-  default: false,
-});

--- a/src/styles/style.d.ts
+++ b/src/styles/style.d.ts
@@ -27,6 +27,14 @@ declare module 'styled-components' {
       Pic_Body2_Pretendard_Bold_16: SerializedStyles;
       Pic_Caption1_Pretendard_Semibold_12: SerializedStyles;
       Pic_Caption2_Pretendard_Semibold_14: SerializedStyles;
+      Pic_Noto_B_Title_1: SerializedStyles;
+      Pic_Noto_SB_Title_2: SerializedStyles;
+      Pic_Noto_M_Subtitle_1: SerializedStyles;
+      Pic_Noto_SB_Subtitle_2: SerializedStyles;
+      Pic_Noto_M_Subtitle_3: SerializedStyles;
+      Pic_Noto_M_Subtitle_4: SerializedStyles;
+      Pic_Noto_M_Subtitle_5: SerializedStyles;
+      Pic_Noto_SB_Subtitle_6: SerializedStyles;
     };
   }
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -54,8 +54,7 @@ const fonts = {
     font-family: 'PretendardSemiBold', sans-serif;
     font-style: normal;
     font-weight: 500;
-    font-size: 20px;
-    line-height: 24px;
+    font-size: 2rem;
     line-height: 2.148rem;
   `,
   Pic_Body1_Pretendard_Medium_16: css`
@@ -106,48 +105,48 @@ const fonts = {
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 500;
-    font-size: 12px;
-    line-height: 16px;
+    font-size: 1.2rem;
+    line-height: 1.6rem;
     letter-spacing: -0.05em;
   `,
   Pic_Noto_SB_Subtitle_2: css`
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 600;
-    font-size: 12px;
-    line-height: 16px;
+    font-size: 1.2rem;
+    line-height: 1.6rem;
     letter-spacing: -0.02em;
   `,
   Pic_Noto_M_Subtitle_3: css`
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 500;
-    font-size: 16px;
-    line-height: 22px;
+    font-size: 1.6rem;
+    line-height: 2.2rem;
     letter-spacing: -0.02em;
   `,
   Pic_Noto_M_Subtitle_4: css`
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 500;
-    font-size: 12px;
-    line-height: 16px;
+    font-size: 1.2rem;
+    line-height: 1.6rem;
     letter-spacing: -0.02em;
   `,
   Pic_Noto_M_Subtitle_5: css`
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 500;
-    font-size: 14px;
-    line-height: 19px;
+    font-size: 1.4rem;
+    line-height: 1.9rem;
     letter-spacing: -0.05em;
   `,
   Pic_Noto_SB_Subtitle_6: css`
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 600;
-    font-size: 14px;
-    line-height: 19px;
+    font-size: 1.4rem;
+    line-height: 1.9rem;
     letter-spacing: -0.05em;
   `,
 };

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -86,6 +86,70 @@ const fonts = {
     font-style: normal;
     line-height: 1.671rem;
   `,
+  Pic_Noto_B_Title_1: css`
+    font-family: 'Noto Sans';
+    font-style: normal;
+    font-weight: 700;
+    font-size: 2rem;
+    line-height: 2.7rem;
+    letter-spacing: -0.03em;
+  `,
+  Pic_Noto_SB_Title_2: css`
+    font-family: 'Noto Sans';
+    font-style: normal;
+    font-weight: 600;
+    font-size: 1.6rem;
+    line-height: 2.2rem;
+    letter-spacing: -0.02em;
+  `,
+  Pic_Noto_M_Subtitle_1: css`
+    font-family: 'Noto Sans';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 16px;
+    letter-spacing: -0.05em;
+  `,
+  Pic_Noto_SB_Subtitle_2: css`
+    font-family: 'Noto Sans';
+    font-style: normal;
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 16px;
+    letter-spacing: -0.02em;
+  `,
+  Pic_Noto_M_Subtitle_3: css`
+    font-family: 'Noto Sans';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 22px;
+    letter-spacing: -0.02em;
+  `,
+  Pic_Noto_M_Subtitle_4: css`
+    font-family: 'Noto Sans';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 16px;
+    letter-spacing: -0.02em;
+  `,
+  Pic_Noto_M_Subtitle_5: css`
+    font-family: 'Noto Sans';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 19px;
+    letter-spacing: -0.05em;
+  `,
+  Pic_Noto_SB_Subtitle_6: css`
+    font-family: 'Noto Sans';
+    font-style: normal;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 19px;
+    letter-spacing: -0.05em;
+  `,
 };
 
 const theme: DefaultTheme = {


### PR DESCRIPTION
## 🔥 Related Issues
resolved #167 

## 💜 작업 내용
- [x] **`Home`** 아이폰 safari에서 상태바 색상을 동적으로 변경하는 기능을 추가하였습니다. (디자인 파트 요청사항)
- [x] **`Home`** 햄버거 메뉴 X버튼 터치 영역이 햄버거 메뉴의 `onClickOutSide` 이벤트와 중복되는 이슈가 있어서, 이를 리팩토링하였습니다.
- [x] **`useModal.tsx`** 커스텀 훅을 리팩토링하였습니다.
- [x] **`Footer`** 스타일가이드 디자인파트 수정 사항을 반영하였습니다.

## ✅ PR Point
### (1) 아이폰 safari에서 url마다 상태바 색상을 페이지 색상에 맞게 동적으로 변경하는 커스텀 훅을 추가하였습니다.
- `useStatusBarColor` 커스텀 훅을 통해 현재 경로에 따라 상태 표시줄 색상을 설정하고, 이를 메타 태그에 적용합니다.
``` jsx
// useStatusBarColor.tsx
import { useLayoutEffect, useMemo } from 'react';
import { useLocation } from 'react-router-dom';

// ✅ 페이지별 상태바 색상 상수로 선언
export const STATUS_BAR_COLOR = {
  LANDING_PAGE: '#FF6A69',
  AUTH_PAGE: '#1E1F21',
  GENERAL_PAGE: '#FFFFFF',
};

// ✅ 각 페이지의 경로에 따라 상태 표시줄 색상 매핑
export const STATUS_BAR_COLOR_USAGE = new Map([
  ['/', STATUS_BAR_COLOR.LANDING_PAGE],
  ['/login', STATUS_BAR_COLOR.AUTH_PAGE],
  ['/signup', STATUS_BAR_COLOR.AUTH_PAGE],
  ['/mypage', STATUS_BAR_COLOR.AUTH_PAGE],
]);

const useStatusBarColor = () => {
  const location = useLocation();

  const statusBarColor = useMemo(
useStatusBarColor
    // ✅ 현재 경로에 해당하는 색상이 STATUS_BAR_COLOR_USAGE 맵 객체에 있다면 해당 색상을 사용하고, 없다면 기본 색상인 흰색 사용
    () => STATUS_BAR_COLOR_USAGE.get(location.pathname) ?? STATUS_BAR_COLOR.GENERAL_PAGE,
    [location],
  );

  // ✅ 빠른 렌더링을 위해 useLayoutEffect 훅을 사용하여, 상태바 색상을 변경하는 작업을 DOM이 그려지기 전에 수행하도록 함
  useLayoutEffect(() => {
    const metaElement = document.getElementById('status-bar');
    if (!metaElement) return;
    (metaElement as HTMLMetaElement).content = statusBarColor;
  }, [statusBarColor]);
};

export default useStatusBarColor;
```

- `useStatusBarColor` 훅을 전역 라우터에서 호출합니다.
``` jsx
// StatusBarForiOS.tsx
import React from 'react';

import useStatusBarColor from '../../lib/hooks/useStatusBarColor';

// ✅ useStatusBarColor 훅을 호출하는 컴포넌트
const StatusBarForiOS = () => {
  useStatusBarColor();
  return <></>;
};

export default StatusBarForiOS;

```
```jsx
// Router.tsx
const Router = () => (
  <BrowserRouter>
    <RecoilRoot>
      <Suspense>
        // ✅ StatusBarForiOS 컴포넌트 라우터 전역 호출
        <StatusBarForiOS />
        <Routes>
          <Route path="/" element={<Onboarding />} />
          <Route path="/login" element={<Login />} />
```

### (2) 햄버거 메뉴의 X버튼 클릭 이벤트와, 햄버거 메뉴 바깥 영역을 클릭하면 닫히는 이벤트가 중복되어서 X버튼 클릭 영역이 바뀌는 이슈가 있어서 해당 부분을 리팩토링하였습니다.

- `Hamburger.tsx` 컴포넌트 내부에 있던  `onClickOutSide` 함수를 재사용성을 위해 커스텀 훅으로 생성하였습니다.
```jsx
// useOnClickOutside.tsx
import { RefObject, useEffect } from 'react';

type Event = MouseEvent | TouchEvent;

interface UseOnClickOutsideProps {
  ref: RefObject<HTMLElement>;
  handler: (event: Event) => void;
}

const useOnClickOutside = ({ ref, handler }: UseOnClickOutsideProps) => {
  const handleClickOutside = (event: Event) => {
    // ✅ ref가 가리키는 DOM 요소 외부를 클릭하면 handler 함수를 실행
    if (ref.current && !ref.current.contains(event.target as Node)) {
      handler(event);
    }
  };

  useEffect(() => {
    document.addEventListener('mousedown', handleClickOutside);
    document.addEventListener('touchstart', handleClickOutside);
    return () => {
      document.removeEventListener('mousedown', handleClickOutside);
      document.removeEventListener('touchstart', handleClickOutside);
    };
  }, [ref, handler]);

  return handleClickOutside;
};

export default useOnClickOutside;
```
- 기존에 '외부 영역'을 `Nav` 컴포넌트 내부에 있는 `Hamburger` 컴포넌트 바깥으로 지정했었던 것을 -> 상위 컴포넌트인 `Nav` 외부 영역으로 변경하였습니다.

### (3) `useModal` 훅을 리팩토링하였습니다.
- 인터페이스를 지정하여 타입을 명시해 주었고, `toggle` 함수를 부정 값을 반환하는 콜백 함수로 변경하였습니다.
 
``` jsx
import { useState } from 'react';

interface ModalState {
  isShowing: boolean;
  toggle: () => void;
}

const useModal = (): ModalState => {
  const [isShowing, setIsShowing] = useState(false);

  const toggle = () => setIsShowing((prev) => !prev);

  return {
    isShowing,
    toggle,
  };
};

export default useModal;
```

### (4) `Footer`에서 기존에 스타일가이드로 미지정되어있던 부분을 스타일가이드에 새롭게 추가된 폰트들로 변경했습니다.

## 😡 Trouble Shooting
- `useStatusBarColor` 훅을 전역적으로 호출하려면 어디에서 불러와야 하는건지 모르겠어서 이것저것 시도해보다가 주함오빠에게 도움을 요청해서, 위와 같은 방식으로 호출했습니다!
- 햄버거 메뉴... 터치영역... 이게 이렇게 오랜 시간 이슈를 해결하게 만들줄이야....^^.... 하지만 덕분에 forwardRef라는 것도 알게 되어서 좋았습니다... ㅎㅎ!ㅋㅋ

## 👀 스크린샷 / GIF / 링크
- 아이폰 사파리 브라우저에서, 상태바 색상이 화면마다 화면의 색상을 반영하여 변경됩니다.

![image1](https://user-images.githubusercontent.com/73213437/224233971-03075545-3a53-4a1d-94f6-585887148e50.png) |![image2](https://user-images.githubusercontent.com/73213437/224233998-6783a240-cfa8-41d6-a28e-f2554dc1d03f.png)|![image3](https://user-images.githubusercontent.com/73213437/224234017-5a01b024-a2f2-4a67-9a29-970e6d49068a.png)|![image4](https://user-images.githubusercontent.com/73213437/224234035-91ab20b6-5094-4df9-8863-0e81b2cafa00.png)
--- | --- | --- | --- | 


## 📚 Reference
- https://deemmun.tistory.com/m/71
- https://merrily-code.tistory.com/46
- https://hyeon.pro/dev/click-event-outside-the-component/
- https://hashnode.com/post/useonclickoutside-custom-hook-to-detect-the-mouse-click-on-outside-typescript-ckrejmy3h0k5r91s18iu42t28
